### PR TITLE
Add password reset test

### DIFF
--- a/resources/views/auth/passwords/email.blade.php
+++ b/resources/views/auth/passwords/email.blade.php
@@ -21,7 +21,7 @@
                                 <label for="email" class="col-md-4 col-form-label text-md-right">{{ __('E-Mail Address') }}</label>
 
                                 <div class="col-md-6">
-                                    <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" required>
+                                    <input id="email" type="email" class="form-control{{ $errors->has('email') ? ' is-invalid' : '' }}" name="email" value="{{ old('email') }}" dusk="email">
 
                                     @if ($errors->has('email'))
                                         <span class="invalid-feedback">
@@ -33,7 +33,7 @@
 
                             <div class="form-group row mb-0">
                                 <div class="col-md-6 offset-md-4">
-                                    <button type="submit" class="btn btn-primary">
+                                    <button type="submit" class="btn btn-primary" dusk="send-password-reset">
                                         {{ __('Send Password Reset Link') }}
                                     </button>
                                 </div>

--- a/tests/Browser/PasswordResetTest.php
+++ b/tests/Browser/PasswordResetTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Browser;
+
+use Laravel\Dusk\Browser;
+use Tests\DuskTestCase;
+
+class PasswordResetTest extends DuskTestCase
+{
+    public function test_you_can_see_password_reset_form()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit(route('password.request'))
+                ->assertSee('Reset Password');
+        });
+    }
+
+    public function test_it_detects_missing_fields()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit(route('password.request'))
+                ->click('@send-password-reset')
+                ->assertSee('email field is required');
+        });
+    }
+
+    public function test_it_detects_non_existing_emails()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit(route('password.request'))
+                ->type('@email', 'janedoe@example.com')
+                ->click('@send-password-reset')
+                ->assertSee("can't find a user with that e-mail address");
+        });
+    }
+
+    public function test_it_can_reset_a_password()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser
+                ->visit(route('password.request'))
+                ->type('@email', 'cgpitt@gmail.com')
+                ->click('@send-password-reset')
+                ->pause(500)
+                ->assertSee('We have e-mailed your password reset link!');
+        });
+    }
+}


### PR DESCRIPTION
I closed the last PR since my fork got fu@&&^ up. 
I really have no idea how to test the other part of the password reset functionality, where you enter your email and new password and it checks for a valid token in the database in the `password-resets` table. 

Feel free to merge this PR now, and later on I'll keep adding more tests.